### PR TITLE
increase Z_LINELEN and fix the compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ OSFLAG=
 #TLIB=Hcurses /lib/libtermcap.a 
 #
 TFLAG=-DM_TERMINFO 
-TLIB=curses
+TLIB=ncurses
 
 #
 #	3) SELECTION OF WINDOW MANAGER AVAILABILITY
@@ -79,7 +79,7 @@ HFILES=misc.h strings.h line.h float.h floatrep.h tol.h command.h comment.h toke
 OTHER=README Makefile Sample.1 Sample.2 Sample.3 Sample.4 paper.ms paper.out
 MANPAGE=spiff.1
 
-CFLAGS=$(OSFLAG) $(TFLAG) $(VISFLAG) -DNOCHATTER
+CFLAGS=$(OSFLAG) $(TFLAG) $(VISFLAG) -ansi -DNOCHATTER
 
 default: spiff
 

--- a/floatrep.h
+++ b/floatrep.h
@@ -18,7 +18,7 @@
 **	when evaluated to a string, the fractional part will
 **		not exceed this length
 */
-#define R_MANMAX	330 //accommodates max exponent of a double
+#define R_MANMAX	330
 
 #define R_POSITIVE	0
 #define R_NEGATIVE	1

--- a/miller.c
+++ b/miller.c
@@ -52,10 +52,6 @@ int comflags;
 	**	be sure to allocate max_obj + 1 objects as was done
 	**		in original miller/myers code
 	*/
-    // TEMPORARY HACK - Jerome Henin 05/2014
-    // try to avoid out of bounds error below
-//	script = Z_ALLOC(max_obj+1,E_edit);
-//	last_d = Z_ALLOC(max_obj+1,int);
 	script = Z_ALLOC(10*max_obj+1,E_edit);
 	last_d = Z_ALLOC(10*max_obj+1,int);
 

--- a/misc.h
+++ b/misc.h
@@ -18,7 +18,7 @@
 #endif
 #endif
 
-#define	Z_LINELEN	1024
+#define	Z_LINELEN	8912
 #define	Z_WORDLEN	  20
 
 extern char Z_err_buf[];


### PR DESCRIPTION
This PR increases the line length of reading, uses `ncurses` instead of `curses`, removes C++-style comment lines, adds `-ansi` to gcc flags to make sure the code can be built with newer GCC versions.